### PR TITLE
feat: マルチモニター対応とマップダイアログのUI改善

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,940 +1,943 @@
 {
-  "hotkeys": {
-    "start_stop": "F7",
-    "reset": "F8",
-    "lap": "F9",
-    "undo_lap": "F10",
-    "click_through": "F6"
-  },
-  "text_color": "#e9ffbd",
-  "zone_data": {
-    "Act 1": [
-      {
-        "id": "act1_area1",
-        "zone": "黄昏の岸辺",
-        "level": 1,
-        "zone_en": "The Twilight Strand"
-      },
-      {
-        "id": "act1_area2",
-        "zone": "海岸",
-        "level": 2,
-        "zone_en": "The Coast"
-      },
-      {
-        "id": "act1_area3",
-        "zone": "ぬかるみの干潟",
-        "level": 3,
-        "zone_en": "The Mud Flats"
-      },
-      {
-        "id": "act1_area4",
-        "zone": "海底通路",
-        "level": 3,
-        "zone_en": "The Submerged Passage"
-      },
-      {
-        "id": "act1_area5",
-        "zone": "陸続きの島",
-        "level": 5,
-        "zone_en": "The Tidal Island"
-      },
-      {
-        "id": "act1_area6",
-        "zone": "岩棚",
-        "level": 6,
-        "zone_en": "The Ledge"
-      },
-      {
-        "id": "act1_area7",
-        "zone": "険しい山道",
-        "level": 6,
-        "zone_en": "The Climb"
-      },
-      {
-        "id": "act1_area8",
-        "zone": "牢獄 -下層-",
-        "level": 7,
-        "zone_en": "The Lower Prison"
-      },
-      {
-        "id": "act1_area9",
-        "zone": "水没した海底洞窟",
-        "level": 6,
-        "zone_en": "The Flooded Depths"
-      },
-      {
-        "id": "act1_area10",
-        "zone": "牢獄 -上層-",
-        "level": 8,
-        "zone_en": "The Upper Prison"
-      },
-      {
-        "id": "act1_area11",
-        "zone": "囚人の門",
-        "level": 8,
-        "zone_en": "Prisoner's Gate"
-      },
-      {
-        "id": "act1_area12",
-        "zone": "船の墓場",
-        "level": 6,
-        "zone_en": "The Ship Graveyard"
-      },
-      {
-        "id": "act1_area14",
-        "zone": "憤怒の洞窟",
-        "level": 6,
-        "zone_en": "The Cavern of Wrath"
-      },
-      {
-        "id": "act1_area15",
-        "zone": "怒りの洞窟",
-        "level": 6,
-        "zone_en": "The Cavern of Anger"
-      },
-      {
-        "id": "act1_area13",
-        "zone": "船の墓場の洞窟",
-        "level": 6,
-        "zone_en": "The Ship Graveyard Cave"
-      }
+    "hotkeys": {
+        "start_stop": "F7",
+        "reset": "F8",
+        "lap": "F9",
+        "undo_lap": "F10",
+        "click_through": "F6"
+    },
+    "text_color": "#e9ffbd",
+    "zone_data": {
+        "Act 1": [
+            {
+                "id": "act1_area1",
+                "zone": "黄昏の岸辺",
+                "level": 1,
+                "zone_en": "The Twilight Strand"
+            },
+            {
+                "id": "act1_area2",
+                "zone": "海岸",
+                "level": 2,
+                "zone_en": "The Coast"
+            },
+            {
+                "id": "act1_area3",
+                "zone": "ぬかるみの干潟",
+                "level": 3,
+                "zone_en": "The Mud Flats"
+            },
+            {
+                "id": "act1_area4",
+                "zone": "海底通路",
+                "level": 3,
+                "zone_en": "The Submerged Passage"
+            },
+            {
+                "id": "act1_area5",
+                "zone": "陸続きの島",
+                "level": 5,
+                "zone_en": "The Tidal Island"
+            },
+            {
+                "id": "act1_area6",
+                "zone": "岩棚",
+                "level": 6,
+                "zone_en": "The Ledge"
+            },
+            {
+                "id": "act1_area7",
+                "zone": "険しい山道",
+                "level": 6,
+                "zone_en": "The Climb"
+            },
+            {
+                "id": "act1_area8",
+                "zone": "牢獄 -下層-",
+                "level": 7,
+                "zone_en": "The Lower Prison"
+            },
+            {
+                "id": "act1_area9",
+                "zone": "水没した海底洞窟",
+                "level": 6,
+                "zone_en": "The Flooded Depths"
+            },
+            {
+                "id": "act1_area10",
+                "zone": "牢獄 -上層-",
+                "level": 8,
+                "zone_en": "The Upper Prison"
+            },
+            {
+                "id": "act1_area11",
+                "zone": "囚人の門",
+                "level": 8,
+                "zone_en": "Prisoner's Gate"
+            },
+            {
+                "id": "act1_area12",
+                "zone": "船の墓場",
+                "level": 6,
+                "zone_en": "The Ship Graveyard"
+            },
+            {
+                "id": "act1_area14",
+                "zone": "憤怒の洞窟",
+                "level": 6,
+                "zone_en": "The Cavern of Wrath"
+            },
+            {
+                "id": "act1_area15",
+                "zone": "怒りの洞窟",
+                "level": 6,
+                "zone_en": "The Cavern of Anger"
+            },
+            {
+                "id": "act1_area13",
+                "zone": "船の墓場の洞窟",
+                "level": 6,
+                "zone_en": "The Ship Graveyard Cave"
+            }
+        ],
+        "Act 2": [
+            {
+                "id": "act2_area1",
+                "zone": "南の森",
+                "level": 10,
+                "zone_en": "The Southern Forest"
+            },
+            {
+                "id": "act2_area2",
+                "zone": "荒廃農地",
+                "level": 10,
+                "zone_en": "The Old Fields"
+            },
+            {
+                "id": "act2_area3",
+                "zone": "十字路",
+                "level": 11,
+                "zone_en": "The Crossroads"
+            },
+            {
+                "id": "act2_area4",
+                "zone": "獣の巣",
+                "level": 12,
+                "zone_en": "The Den"
+            },
+            {
+                "id": "act2_area5",
+                "zone": "罪の間 -第一層-",
+                "level": 12,
+                "zone_en": "The Chamber of Sins Level 1"
+            },
+            {
+                "id": "act2_area6",
+                "zone": "罪の間 -第二層-",
+                "level": 13,
+                "zone_en": "The Chamber of Sins Level 2"
+            },
+            {
+                "id": "act2_area7",
+                "zone": "川沿いの道",
+                "level": 13,
+                "zone_en": "The Riverways"
+            },
+            {
+                "id": "act2_area8",
+                "zone": "西の森",
+                "level": 13,
+                "zone_en": "The Western Forest"
+            },
+            {
+                "id": "act2_area9",
+                "zone": "編む者の巣穴",
+                "level": 13,
+                "zone_en": "The Weaver's Chambers"
+            },
+            {
+                "id": "act2_area10",
+                "zone": "壊れた橋",
+                "level": 14,
+                "zone_en": "The Broken Bridge"
+            },
+            {
+                "id": "act2_area11",
+                "zone": "フェルシュラインの遺跡",
+                "level": 14,
+                "zone_en": "The Fellshrine Ruins"
+            },
+            {
+                "id": "act2_area12",
+                "zone": "地下聖堂 -第一層-",
+                "level": 14,
+                "zone_en": "The Crypt Level 1"
+            },
+            {
+                "id": "act2_area13",
+                "zone": "地下聖堂 -第二層-",
+                "level": 15,
+                "zone_en": "The Crypt Level 2"
+            },
+            {
+                "id": "act2_area14",
+                "zone": "湿地",
+                "level": 15,
+                "zone_en": "The Wetlands"
+            },
+            {
+                "id": "act2_area15",
+                "zone": "ヴァールの遺跡",
+                "level": 12,
+                "zone_en": "The Vaal Ruins"
+            },
+            {
+                "id": "act2_area16",
+                "zone": "北の森",
+                "level": 12,
+                "zone_en": "The Northern Forest"
+            },
+            {
+                "id": "act2_area17",
+                "zone": "大洞窟",
+                "level": 12,
+                "zone_en": "The Caverns"
+            },
+            {
+                "id": "act2_area18",
+                "zone": "古代のピラミッド",
+                "level": 12,
+                "zone_en": "The Ancient Pyramid"
+            }
+        ],
+        "Act 3": [
+            {
+                "id": "act3_area1",
+                "zone": "サーン市街",
+                "level": 16,
+                "zone_en": "The City of Sarn"
+            },
+            {
+                "id": "act3_area2",
+                "zone": "スラム",
+                "level": 16,
+                "zone_en": "The Slums"
+            },
+            {
+                "id": "act3_area3",
+                "zone": "火葬場",
+                "level": 17,
+                "zone_en": "The Crematorium"
+            },
+            {
+                "id": "act3_area4",
+                "zone": "下水道",
+                "level": 18,
+                "zone_en": "The Sewers"
+            },
+            {
+                "id": "act3_area5",
+                "zone": "市場",
+                "level": 18,
+                "zone_en": "The Marketplace"
+            },
+            {
+                "id": "act3_area6",
+                "zone": "地下墓地",
+                "level": 19,
+                "zone_en": "The Catacombs"
+            },
+            {
+                "id": "act3_area7",
+                "zone": "戦場",
+                "level": 19,
+                "zone_en": "The Battlefront"
+            },
+            {
+                "id": "act3_area8",
+                "zone": "船着場",
+                "level": 20,
+                "zone_en": "The Docks"
+            },
+            {
+                "id": "act3_area9",
+                "zone": "ソラリス寺院 -第一層-",
+                "level": 21,
+                "zone_en": "The Solaris Temple Level 1"
+            },
+            {
+                "id": "act3_area10",
+                "zone": "ソラリス寺院 -第二層-",
+                "level": 21,
+                "zone_en": "The Solaris Temple Level 2"
+            },
+            {
+                "id": "act3_area11",
+                "zone": "黒檀の兵舎",
+                "level": 22,
+                "zone_en": "The Ebony Barracks"
+            },
+            {
+                "id": "act3_area12",
+                "zone": "ルナリス寺院 -第一層-",
+                "level": 22,
+                "zone_en": "The Lunaris Temple Level 1"
+            },
+            {
+                "id": "act3_area13",
+                "zone": "ルナリス寺院 -第二層-",
+                "level": 23,
+                "zone_en": "The Lunaris Temple Level 2"
+            },
+            {
+                "id": "act3_area14",
+                "zone": "帝国の庭園",
+                "level": 18,
+                "zone_en": "The Imperial Gardens"
+            },
+            {
+                "id": "act3_area15",
+                "zone": "図書館",
+                "level": 18,
+                "zone_en": "The Library"
+            },
+            {
+                "id": "act3_area16",
+                "zone": "公文書館",
+                "level": 18,
+                "zone_en": "The Archives"
+            },
+            {
+                "id": "act3_area17",
+                "zone": "神の杖",
+                "level": 18,
+                "zone_en": "The Sceptre of God"
+            },
+            {
+                "id": "act3_area18",
+                "zone": "神の杖 -上層-",
+                "level": 1,
+                "zone_en": "The Upper Sceptre of God"
+            }
+        ],
+        "Act 4": [
+            {
+                "id": "act4_area1",
+                "zone": "水道橋",
+                "level": 24,
+                "zone_en": "The Aqueduct"
+            },
+            {
+                "id": "act4_area2",
+                "zone": "干上がった湖",
+                "level": 24,
+                "zone_en": "The Dried Lake"
+            },
+            {
+                "id": "act4_area3",
+                "zone": "志す者の広場",
+                "level": 24,
+                "zone_en": "Aspirants' Plaza"
+            },
+            {
+                "id": "act4_area4",
+                "zone": "鉱山 -第一層-",
+                "level": 25,
+                "zone_en": "The Mines Level 1"
+            },
+            {
+                "id": "act4_area5",
+                "zone": "鉱山 -第二層-",
+                "level": 25,
+                "zone_en": "The Mines Level 2"
+            },
+            {
+                "id": "act4_area6",
+                "zone": "水晶鉱脈",
+                "level": 26,
+                "zone_en": "The Crystal Veins"
+            },
+            {
+                "id": "act4_area7",
+                "zone": "ダレッソの夢",
+                "level": 26,
+                "zone_en": "Daresso's Dream"
+            },
+            {
+                "id": "act4_area8",
+                "zone": "大闘技場",
+                "level": 26,
+                "zone_en": "The Grand Arena"
+            },
+            {
+                "id": "act4_area9",
+                "zone": "カオムの夢",
+                "level": 27,
+                "zone_en": "Kaom's Dream"
+            },
+            {
+                "id": "act4_area10",
+                "zone": "カオムの要塞",
+                "level": 27,
+                "zone_en": "Kaom's Stronghold"
+            },
+            {
+                "id": "act4_area11",
+                "zone": "魔獣の内部 -第一層-",
+                "level": 27,
+                "zone_en": "The Belly of the Beast Level 1"
+            },
+            {
+                "id": "act4_area12",
+                "zone": "魔獣の内部 -第二層-",
+                "level": 27,
+                "zone_en": "The Belly of the Beast Level 2"
+            },
+            {
+                "id": "act4_area13",
+                "zone": "魔獣の深部",
+                "level": 28
+            },
+            {
+                "id": "act4_area14",
+                "zone": "摘出",
+                "level": 28,
+                "zone_en": "The Harvest"
+            },
+            {
+                "id": "act4_area15",
+                "zone": "頂への道",
+                "level": 24,
+                "zone_en": "The Ascent"
+            }
+        ],
+        "Act 5": [
+            {
+                "id": "act5_area1",
+                "zone": "奴隷収容所",
+                "level": 29,
+                "zone_en": "The Slave Pens"
+            },
+            {
+                "id": "act5_area2",
+                "zone": "奴隷管理区画",
+                "level": 30,
+                "zone_en": "The Control Blocks"
+            },
+            {
+                "id": "act5_area3",
+                "zone": "オリアス広場",
+                "level": 30,
+                "zone_en": "Oriath Square"
+            },
+            {
+                "id": "act5_area4",
+                "zone": "テンプラーの裁判所",
+                "level": 31,
+                "zone_en": "The Templar Courts"
+            },
+            {
+                "id": "act5_area5",
+                "zone": "イノセンスの間",
+                "level": 31,
+                "zone_en": "The Chamber of Innocence"
+            },
+            {
+                "id": "act5_area6",
+                "zone": "焼けた裁判所",
+                "level": 32,
+                "zone_en": "The Torched Courts"
+            },
+            {
+                "id": "act5_area7",
+                "zone": "破壊された広場",
+                "level": 32,
+                "zone_en": "The Ruined Square"
+            },
+            {
+                "id": "act5_area8",
+                "zone": "納骨堂",
+                "level": 33,
+                "zone_en": "The Ossuary"
+            },
+            {
+                "id": "act5_area9",
+                "zone": "聖廟",
+                "level": 30,
+                "zone_en": "The Reliquary"
+            },
+            {
+                "id": "act5_area10",
+                "zone": "大聖堂の屋上",
+                "level": 30,
+                "zone_en": "The Cathedral Rooftop"
+            }
+        ],
+        "Act 6": [
+            {
+                "id": "act6_area1",
+                "zone": "黄昏の岸辺",
+                "level": 34,
+                "zone_en": "The Twilight Strand"
+            },
+            {
+                "id": "act6_area2",
+                "zone": "海岸",
+                "level": 35,
+                "zone_en": "The Coast"
+            },
+            {
+                "id": "act6_area3",
+                "zone": "ぬかるみの干潟",
+                "level": 35,
+                "zone_en": "The Mud Flats"
+            },
+            {
+                "id": "act6_area4",
+                "zone": "カルイの要塞",
+                "level": 35,
+                "zone_en": "The Karui Fortress"
+            },
+            {
+                "id": "act6_area5",
+                "zone": "尾根",
+                "level": 37,
+                "zone_en": "The Ridge"
+            },
+            {
+                "id": "act6_area6",
+                "zone": "牢獄 -下層-",
+                "level": 37,
+                "zone_en": "The Lower Prison"
+            },
+            {
+                "id": "act6_area7",
+                "zone": "シャヴロンの塔",
+                "level": 37,
+                "zone_en": "Shavronne's Tower"
+            },
+            {
+                "id": "act6_area8",
+                "zone": "囚人の門",
+                "level": 38,
+                "zone_en": "Prisoner's Gate"
+            },
+            {
+                "id": "act6_area9",
+                "zone": "西の森",
+                "level": 38,
+                "zone_en": "The Western Forest"
+            },
+            {
+                "id": "act6_area10",
+                "zone": "川沿いの道",
+                "level": 39,
+                "zone_en": "The Riverways"
+            },
+            {
+                "id": "act6_area11",
+                "zone": "湿地",
+                "level": 39,
+                "zone_en": "The Wetlands"
+            },
+            {
+                "id": "act6_area12",
+                "zone": "南の森",
+                "level": 40,
+                "zone_en": "The Southern Forest"
+            },
+            {
+                "id": "act6_area13",
+                "zone": "怒りの洞窟",
+                "level": 40,
+                "zone_en": "The Cavern of Anger"
+            },
+            {
+                "id": "act6_area14",
+                "zone": "ビーコン",
+                "level": 40,
+                "zone_en": "The Beacon"
+            },
+            {
+                "id": "act6_area15",
+                "zone": "海水の王の岩礁",
+                "level": 36,
+                "zone_en": "The Brine King's Reef"
+            }
+        ],
+        "Act 7": [
+            {
+                "id": "act7_area1",
+                "zone": "壊れた橋",
+                "level": 41,
+                "zone_en": "The Broken Bridge"
+            },
+            {
+                "id": "act7_area2",
+                "zone": "十字路",
+                "level": 42,
+                "zone_en": "The Crossroads"
+            },
+            {
+                "id": "act7_area3",
+                "zone": "フェルシュラインの遺跡",
+                "level": 42,
+                "zone_en": "The Fellshrine Ruins"
+            },
+            {
+                "id": "act7_area4",
+                "zone": "地下聖堂",
+                "level": 42,
+                "zone_en": "The Crypt"
+            },
+            {
+                "id": "act7_area5",
+                "zone": "罪の間 -第一層-",
+                "level": 42,
+                "zone_en": "The Chamber of Sins Level 1"
+            },
+            {
+                "id": "act7_area6",
+                "zone": "マリガロの聖域",
+                "level": 42,
+                "zone_en": "Maligaro's Sanctum"
+            },
+            {
+                "id": "act7_area7",
+                "zone": "罪の間 -第二層-",
+                "level": 42,
+                "zone_en": "The Chamber of Sins Level 2"
+            },
+            {
+                "id": "act7_area8",
+                "zone": "獣の巣",
+                "level": 42,
+                "zone_en": "The Den"
+            },
+            {
+                "id": "act7_area9",
+                "zone": "焼け野原",
+                "level": 42,
+                "zone_en": "The Ashen Fields"
+            },
+            {
+                "id": "act7_area10",
+                "zone": "北の森",
+                "level": 42,
+                "zone_en": "The Northern Forest"
+            },
+            {
+                "id": "act7_area11",
+                "zone": "囚人の門",
+                "level": 42,
+                "zone_en": "Prisoner's Gate"
+            },
+            {
+                "id": "act7_area12",
+                "zone": "恐怖の密林",
+                "level": 42,
+                "zone_en": "The Dread Thicket"
+            },
+            {
+                "id": "act7_area13",
+                "zone": "土手道",
+                "level": 42,
+                "zone_en": "The Causeway"
+            },
+            {
+                "id": "act7_area14",
+                "zone": "ヴァールの街",
+                "level": 42,
+                "zone_en": "The Vaal City"
+            },
+            {
+                "id": "act7_area15",
+                "zone": "堕落の寺院 -第一層-",
+                "level": 42,
+                "zone_en": "The Temple of Decay Level 1"
+            },
+            {
+                "id": "act7_area16",
+                "zone": "堕落の寺院 -第二層-",
+                "level": 42,
+                "zone_en": "The Temple of Decay Level 2"
+            }
+        ],
+        "Act 8": [
+            {
+                "id": "act8_area1",
+                "zone": "サーンの城壁",
+                "level": 46,
+                "zone_en": "The Sarn Ramparts"
+            },
+            {
+                "id": "act8_area2",
+                "zone": "志す者の広場",
+                "level": 46,
+                "zone_en": "Aspirants' Plaza"
+            },
+            {
+                "id": "act8_area3",
+                "zone": "有毒な排水路",
+                "level": 47,
+                "zone_en": "The Toxic Conduits"
+            },
+            {
+                "id": "act8_area4",
+                "zone": "ドードリの汚水槽",
+                "level": 47,
+                "zone_en": "Doedre's Cesspool"
+            },
+            {
+                "id": "act8_area5",
+                "zone": "大釜",
+                "level": 48
+            },
+            {
+                "id": "act8_area6",
+                "zone": "波止場",
+                "level": 48,
+                "zone_en": "The Quay"
+            },
+            {
+                "id": "act8_area7",
+                "zone": "復活の地",
+                "level": 49
+            },
+            {
+                "id": "act8_area8",
+                "zone": "穀物倉庫",
+                "level": 49,
+                "zone_en": "The Grain Gate"
+            },
+            {
+                "id": "act8_area9",
+                "zone": "帝国の穀倉地帯",
+                "level": 50,
+                "zone_en": "The Imperial Fields"
+            },
+            {
+                "id": "act8_area10",
+                "zone": "ソラリス寺院 -第一層-",
+                "level": 50,
+                "zone_en": "The Solaris Temple Level 1"
+            },
+            {
+                "id": "act8_area11",
+                "zone": "ソラリス寺院 -第二層-",
+                "level": 50,
+                "zone_en": "The Solaris Temple Level 2"
+            },
+            {
+                "id": "act8_area12",
+                "zone": "ソラリスの中央広場",
+                "level": 50,
+                "zone_en": "The Solaris Concourse"
+            },
+            {
+                "id": "act8_area13",
+                "zone": "港の橋",
+                "level": 51,
+                "zone_en": "The Harbour Bridge"
+            },
+            {
+                "id": "act8_area14",
+                "zone": "ルナリスの中央広場",
+                "level": 51,
+                "zone_en": "The Lunaris Concourse"
+            },
+            {
+                "id": "act8_area15",
+                "zone": "ルナリス寺院 -第一層-",
+                "level": 51,
+                "zone_en": "The Lunaris Temple Level 1"
+            },
+            {
+                "id": "act8_area16",
+                "zone": "ルナリス寺院 -第二層-",
+                "level": 52,
+                "zone_en": "The Lunaris Temple Level 2"
+            },
+            {
+                "id": "act8_area17",
+                "zone": "血の水道橋",
+                "level": 48,
+                "zone_en": "The Blood Aqueduct"
+            },
+            {
+                "id": "act8_area18",
+                "zone": "浴場",
+                "level": 48,
+                "zone_en": "The Bath House"
+            },
+            {
+                "id": "act8_area19",
+                "zone": "空中庭園",
+                "level": 48,
+                "zone_en": "The High Gardens"
+            }
+        ],
+        "Act 9": [
+            {
+                "id": "act9_area1",
+                "zone": "谷底への道",
+                "level": 53,
+                "zone_en": "The Descent"
+            },
+            {
+                "id": "act9_area2",
+                "zone": "ヴァスティリ砂漠",
+                "level": 53,
+                "zone_en": "The Vastiri Desert"
+            },
+            {
+                "id": "act9_area3",
+                "zone": "オアシス",
+                "level": 54,
+                "zone_en": "The Oasis"
+            },
+            {
+                "id": "act9_area4",
+                "zone": "山麓",
+                "level": 54,
+                "zone_en": "The Foothills"
+            },
+            {
+                "id": "act9_area5",
+                "zone": "沸き立つ湖",
+                "level": 54,
+                "zone_en": "The Boiling Lake"
+            },
+            {
+                "id": "act9_area6",
+                "zone": "坑道",
+                "level": 54,
+                "zone_en": "The Tunnel"
+            },
+            {
+                "id": "act9_area7",
+                "zone": "採石場",
+                "level": 54,
+                "zone_en": "The Quarry"
+            },
+            {
+                "id": "act9_area8",
+                "zone": "精錬所",
+                "level": 54,
+                "zone_en": "The Refinery"
+            },
+            {
+                "id": "act9_area9",
+                "zone": "魔獣の内部",
+                "level": 54,
+                "zone_en": "The Belly of the Beast"
+            },
+            {
+                "id": "act9_area10",
+                "zone": "腐った核",
+                "level": 54,
+                "zone_en": "The Rotting Core"
+            }
+        ],
+        "Act 10": [
+            {
+                "id": "act10_area1",
+                "zone": "大聖堂の屋上",
+                "level": 58,
+                "zone_en": "The Cathedral Rooftop"
+            },
+            {
+                "id": "act10_area2",
+                "zone": "聖堂の屋上",
+                "level": 58
+            },
+            {
+                "id": "act10_area3",
+                "zone": "荒廃した広場",
+                "level": 59,
+                "zone_en": "The Ravaged Square"
+            },
+            {
+                "id": "act10_area4",
+                "zone": "奴隷管理区画",
+                "level": 60,
+                "zone_en": "The Control Blocks"
+            },
+            {
+                "id": "act10_area5",
+                "zone": "納骨堂",
+                "level": 61,
+                "zone_en": "The Ossuary"
+            },
+            {
+                "id": "act10_area6",
+                "zone": "焼けた裁判所",
+                "level": 62,
+                "zone_en": "The Torched Courts"
+            },
+            {
+                "id": "act10_area7",
+                "zone": "冒涜された広間",
+                "level": 63,
+                "zone_en": "The Desecrated Chambers"
+            },
+            {
+                "id": "act10_area8",
+                "zone": "志す者の広場",
+                "level": 67,
+                "zone_en": "Aspirants' Plaza"
+            },
+            {
+                "id": "act10_area9",
+                "zone": "運河",
+                "level": 60,
+                "zone_en": "The Canals"
+            },
+            {
+                "id": "act10_area10",
+                "zone": "餌場",
+                "level": 60,
+                "zone_en": "The Feeding Trough"
+            },
+            {
+                "id": "act10_area11",
+                "zone": "渇望の祭壇",
+                "level": 60
+            }
+        ]
+    },
+    "guide_expanded": true,
+    "guide_font_size": 18,
+    "town_zones": [
+        "Lioneye's Watch",
+        "ライオンアイの見張り場",
+        "The Forest Encampment",
+        "森の野営地",
+        "The Sarn Encampment",
+        "サーンの野営地",
+        "Highgate",
+        "ハイゲート",
+        "Overseer's Tower",
+        "監督官の塔",
+        "The Bridge Encampment",
+        "橋の野営地",
+        "Oriath Docks",
+        "オリアスの船着場",
+        "Karui Shores",
+        "カルイの海岸"
     ],
-    "Act 2": [
-      {
-        "id": "act2_area1",
-        "zone": "南の森",
-        "level": 10,
-        "zone_en": "The Southern Forest"
-      },
-      {
-        "id": "act2_area2",
-        "zone": "荒廃農地",
-        "level": 10,
-        "zone_en": "The Old Fields"
-      },
-      {
-        "id": "act2_area3",
-        "zone": "十字路",
-        "level": 11,
-        "zone_en": "The Crossroads"
-      },
-      {
-        "id": "act2_area4",
-        "zone": "獣の巣",
-        "level": 12,
-        "zone_en": "The Den"
-      },
-      {
-        "id": "act2_area5",
-        "zone": "罪の間 -第一層-",
-        "level": 12,
-        "zone_en": "The Chamber of Sins Level 1"
-      },
-      {
-        "id": "act2_area6",
-        "zone": "罪の間 -第二層-",
-        "level": 13,
-        "zone_en": "The Chamber of Sins Level 2"
-      },
-      {
-        "id": "act2_area7",
-        "zone": "川沿いの道",
-        "level": 13,
-        "zone_en": "The Riverways"
-      },
-      {
-        "id": "act2_area8",
-        "zone": "西の森",
-        "level": 13,
-        "zone_en": "The Western Forest"
-      },
-      {
-        "id": "act2_area9",
-        "zone": "編む者の巣穴",
-        "level": 13,
-        "zone_en": "The Weaver's Chambers"
-      },
-      {
-        "id": "act2_area10",
-        "zone": "壊れた橋",
-        "level": 14,
-        "zone_en": "The Broken Bridge"
-      },
-      {
-        "id": "act2_area11",
-        "zone": "フェルシュラインの遺跡",
-        "level": 14,
-        "zone_en": "The Fellshrine Ruins"
-      },
-      {
-        "id": "act2_area12",
-        "zone": "地下聖堂 -第一層-",
-        "level": 14,
-        "zone_en": "The Crypt Level 1"
-      },
-      {
-        "id": "act2_area13",
-        "zone": "地下聖堂 -第二層-",
-        "level": 15,
-        "zone_en": "The Crypt Level 2"
-      },
-      {
-        "id": "act2_area14",
-        "zone": "湿地",
-        "level": 15,
-        "zone_en": "The Wetlands"
-      },
-      {
-        "id": "act2_area15",
-        "zone": "ヴァールの遺跡",
-        "level": 12,
-        "zone_en": "The Vaal Ruins"
-      },
-      {
-        "id": "act2_area16",
-        "zone": "北の森",
-        "level": 12,
-        "zone_en": "The Northern Forest"
-      },
-      {
-        "id": "act2_area17",
-        "zone": "大洞窟",
-        "level": 12,
-        "zone_en": "The Caverns"
-      },
-      {
-        "id": "act2_area18",
-        "zone": "古代のピラミッド",
-        "level": 12,
-        "zone_en": "The Ancient Pyramid"
-      }
-    ],
-    "Act 3": [
-      {
-        "id": "act3_area1",
-        "zone": "サーン市街",
-        "level": 16,
-        "zone_en": "The City of Sarn"
-      },
-      {
-        "id": "act3_area2",
-        "zone": "スラム",
-        "level": 16,
-        "zone_en": "The Slums"
-      },
-      {
-        "id": "act3_area3",
-        "zone": "火葬場",
-        "level": 17,
-        "zone_en": "The Crematorium"
-      },
-      {
-        "id": "act3_area4",
-        "zone": "下水道",
-        "level": 18,
-        "zone_en": "The Sewers"
-      },
-      {
-        "id": "act3_area5",
-        "zone": "市場",
-        "level": 18,
-        "zone_en": "The Marketplace"
-      },
-      {
-        "id": "act3_area6",
-        "zone": "地下墓地",
-        "level": 19,
-        "zone_en": "The Catacombs"
-      },
-      {
-        "id": "act3_area7",
-        "zone": "戦場",
-        "level": 19,
-        "zone_en": "The Battlefront"
-      },
-      {
-        "id": "act3_area8",
-        "zone": "船着場",
-        "level": 20,
-        "zone_en": "The Docks"
-      },
-      {
-        "id": "act3_area9",
-        "zone": "ソラリス寺院 -第一層-",
-        "level": 21,
-        "zone_en": "The Solaris Temple Level 1"
-      },
-      {
-        "id": "act3_area10",
-        "zone": "ソラリス寺院 -第二層-",
-        "level": 21,
-        "zone_en": "The Solaris Temple Level 2"
-      },
-      {
-        "id": "act3_area11",
-        "zone": "黒檀の兵舎",
-        "level": 22,
-        "zone_en": "The Ebony Barracks"
-      },
-      {
-        "id": "act3_area12",
-        "zone": "ルナリス寺院 -第一層-",
-        "level": 22,
-        "zone_en": "The Lunaris Temple Level 1"
-      },
-      {
-        "id": "act3_area13",
-        "zone": "ルナリス寺院 -第二層-",
-        "level": 23,
-        "zone_en": "The Lunaris Temple Level 2"
-      },
-      {
-        "id": "act3_area14",
-        "zone": "帝国の庭園",
-        "level": 18,
-        "zone_en": "The Imperial Gardens"
-      },
-      {
-        "id": "act3_area15",
-        "zone": "図書館",
-        "level": 18,
-        "zone_en": "The Library"
-      },
-      {
-        "id": "act3_area16",
-        "zone": "公文書館",
-        "level": 18,
-        "zone_en": "The Archives"
-      },
-      {
-        "id": "act3_area17",
-        "zone": "神の杖",
-        "level": 18,
-        "zone_en": "The Sceptre of God"
-      },
-      {
-        "id": "act3_area18",
-        "zone": "神の杖 -上層-",
-        "level": 1,
-        "zone_en": "The Upper Sceptre of God"
-      }
-    ],
-    "Act 4": [
-      {
-        "id": "act4_area1",
-        "zone": "水道橋",
-        "level": 24,
-        "zone_en": "The Aqueduct"
-      },
-      {
-        "id": "act4_area2",
-        "zone": "干上がった湖",
-        "level": 24,
-        "zone_en": "The Dried Lake"
-      },
-      {
-        "id": "act4_area3",
-        "zone": "志す者の広場",
-        "level": 24,
-        "zone_en": "Aspirants' Plaza"
-      },
-      {
-        "id": "act4_area4",
-        "zone": "鉱山 -第一層-",
-        "level": 25,
-        "zone_en": "The Mines Level 1"
-      },
-      {
-        "id": "act4_area5",
-        "zone": "鉱山 -第二層-",
-        "level": 25,
-        "zone_en": "The Mines Level 2"
-      },
-      {
-        "id": "act4_area6",
-        "zone": "水晶鉱脈",
-        "level": 26,
-        "zone_en": "The Crystal Veins"
-      },
-      {
-        "id": "act4_area7",
-        "zone": "ダレッソの夢",
-        "level": 26,
-        "zone_en": "Daresso's Dream"
-      },
-      {
-        "id": "act4_area8",
-        "zone": "大闘技場",
-        "level": 26,
-        "zone_en": "The Grand Arena"
-      },
-      {
-        "id": "act4_area9",
-        "zone": "カオムの夢",
-        "level": 27,
-        "zone_en": "Kaom's Dream"
-      },
-      {
-        "id": "act4_area10",
-        "zone": "カオムの要塞",
-        "level": 27,
-        "zone_en": "Kaom's Stronghold"
-      },
-      {
-        "id": "act4_area11",
-        "zone": "魔獣の内部 -第一層-",
-        "level": 27,
-        "zone_en": "The Belly of the Beast Level 1"
-      },
-      {
-        "id": "act4_area12",
-        "zone": "魔獣の内部 -第二層-",
-        "level": 27,
-        "zone_en": "The Belly of the Beast Level 2"
-      },
-      {
-        "id": "act4_area13",
-        "zone": "魔獣の深部",
-        "level": 28
-      },
-      {
-        "id": "act4_area14",
-        "zone": "摘出",
-        "level": 28,
-        "zone_en": "The Harvest"
-      },
-      {
-        "id": "act4_area15",
-        "zone": "頂への道",
-        "level": 24,
-        "zone_en": "The Ascent"
-      }
-    ],
-    "Act 5": [
-      {
-        "id": "act5_area1",
-        "zone": "奴隷収容所",
-        "level": 29,
-        "zone_en": "The Slave Pens"
-      },
-      {
-        "id": "act5_area2",
-        "zone": "奴隷管理区画",
-        "level": 30,
-        "zone_en": "The Control Blocks"
-      },
-      {
-        "id": "act5_area3",
-        "zone": "オリアス広場",
-        "level": 30,
-        "zone_en": "Oriath Square"
-      },
-      {
-        "id": "act5_area4",
-        "zone": "テンプラーの裁判所",
-        "level": 31,
-        "zone_en": "The Templar Courts"
-      },
-      {
-        "id": "act5_area5",
-        "zone": "イノセンスの間",
-        "level": 31,
-        "zone_en": "The Chamber of Innocence"
-      },
-      {
-        "id": "act5_area6",
-        "zone": "焼けた裁判所",
-        "level": 32,
-        "zone_en": "The Torched Courts"
-      },
-      {
-        "id": "act5_area7",
-        "zone": "破壊された広場",
-        "level": 32,
-        "zone_en": "The Ruined Square"
-      },
-      {
-        "id": "act5_area8",
-        "zone": "納骨堂",
-        "level": 33,
-        "zone_en": "The Ossuary"
-      },
-      {
-        "id": "act5_area9",
-        "zone": "聖廟",
-        "level": 30,
-        "zone_en": "The Reliquary"
-      },
-      {
-        "id": "act5_area10",
-        "zone": "大聖堂の屋上",
-        "level": 30,
-        "zone_en": "The Cathedral Rooftop"
-      }
-    ],
-    "Act 6": [
-      {
-        "id": "act6_area1",
-        "zone": "黄昏の岸辺",
-        "level": 34,
-        "zone_en": "The Twilight Strand"
-      },
-      {
-        "id": "act6_area2",
-        "zone": "海岸",
-        "level": 35,
-        "zone_en": "The Coast"
-      },
-      {
-        "id": "act6_area3",
-        "zone": "ぬかるみの干潟",
-        "level": 35,
-        "zone_en": "The Mud Flats"
-      },
-      {
-        "id": "act6_area4",
-        "zone": "カルイの要塞",
-        "level": 35,
-        "zone_en": "The Karui Fortress"
-      },
-      {
-        "id": "act6_area5",
-        "zone": "尾根",
-        "level": 37,
-        "zone_en": "The Ridge"
-      },
-      {
-        "id": "act6_area6",
-        "zone": "牢獄 -下層-",
-        "level": 37,
-        "zone_en": "The Lower Prison"
-      },
-      {
-        "id": "act6_area7",
-        "zone": "シャヴロンの塔",
-        "level": 37,
-        "zone_en": "Shavronne's Tower"
-      },
-      {
-        "id": "act6_area8",
-        "zone": "囚人の門",
-        "level": 38,
-        "zone_en": "Prisoner's Gate"
-      },
-      {
-        "id": "act6_area9",
-        "zone": "西の森",
-        "level": 38,
-        "zone_en": "The Western Forest"
-      },
-      {
-        "id": "act6_area10",
-        "zone": "川沿いの道",
-        "level": 39,
-        "zone_en": "The Riverways"
-      },
-      {
-        "id": "act6_area11",
-        "zone": "湿地",
-        "level": 39,
-        "zone_en": "The Wetlands"
-      },
-      {
-        "id": "act6_area12",
-        "zone": "南の森",
-        "level": 40,
-        "zone_en": "The Southern Forest"
-      },
-      {
-        "id": "act6_area13",
-        "zone": "怒りの洞窟",
-        "level": 40,
-        "zone_en": "The Cavern of Anger"
-      },
-      {
-        "id": "act6_area14",
-        "zone": "ビーコン",
-        "level": 40,
-        "zone_en": "The Beacon"
-      },
-      {
-        "id": "act6_area15",
-        "zone": "海水の王の岩礁",
-        "level": 36,
-        "zone_en": "The Brine King's Reef"
-      }
-    ],
-    "Act 7": [
-      {
-        "id": "act7_area1",
-        "zone": "壊れた橋",
-        "level": 41,
-        "zone_en": "The Broken Bridge"
-      },
-      {
-        "id": "act7_area2",
-        "zone": "十字路",
-        "level": 42,
-        "zone_en": "The Crossroads"
-      },
-      {
-        "id": "act7_area3",
-        "zone": "フェルシュラインの遺跡",
-        "level": 42,
-        "zone_en": "The Fellshrine Ruins"
-      },
-      {
-        "id": "act7_area4",
-        "zone": "地下聖堂",
-        "level": 42,
-        "zone_en": "The Crypt"
-      },
-      {
-        "id": "act7_area5",
-        "zone": "罪の間 -第一層-",
-        "level": 42,
-        "zone_en": "The Chamber of Sins Level 1"
-      },
-      {
-        "id": "act7_area6",
-        "zone": "マリガロの聖域",
-        "level": 42,
-        "zone_en": "Maligaro's Sanctum"
-      },
-      {
-        "id": "act7_area7",
-        "zone": "罪の間 -第二層-",
-        "level": 42,
-        "zone_en": "The Chamber of Sins Level 2"
-      },
-      {
-        "id": "act7_area8",
-        "zone": "獣の巣",
-        "level": 42,
-        "zone_en": "The Den"
-      },
-      {
-        "id": "act7_area9",
-        "zone": "焼け野原",
-        "level": 42,
-        "zone_en": "The Ashen Fields"
-      },
-      {
-        "id": "act7_area10",
-        "zone": "北の森",
-        "level": 42,
-        "zone_en": "The Northern Forest"
-      },
-      {
-        "id": "act7_area11",
-        "zone": "囚人の門",
-        "level": 42,
-        "zone_en": "Prisoner's Gate"
-      },
-      {
-        "id": "act7_area12",
-        "zone": "恐怖の密林",
-        "level": 42,
-        "zone_en": "The Dread Thicket"
-      },
-      {
-        "id": "act7_area13",
-        "zone": "土手道",
-        "level": 42,
-        "zone_en": "The Causeway"
-      },
-      {
-        "id": "act7_area14",
-        "zone": "ヴァールの街",
-        "level": 42,
-        "zone_en": "The Vaal City"
-      },
-      {
-        "id": "act7_area15",
-        "zone": "堕落の寺院 -第一層-",
-        "level": 42,
-        "zone_en": "The Temple of Decay Level 1"
-      },
-      {
-        "id": "act7_area16",
-        "zone": "堕落の寺院 -第二層-",
-        "level": 42,
-        "zone_en": "The Temple of Decay Level 2"
-      }
-    ],
-    "Act 8": [
-      {
-        "id": "act8_area1",
-        "zone": "サーンの城壁",
-        "level": 46,
-        "zone_en": "The Sarn Ramparts"
-      },
-      {
-        "id": "act8_area2",
-        "zone": "志す者の広場",
-        "level": 46,
-        "zone_en": "Aspirants' Plaza"
-      },
-      {
-        "id": "act8_area3",
-        "zone": "有毒な排水路",
-        "level": 47,
-        "zone_en": "The Toxic Conduits"
-      },
-      {
-        "id": "act8_area4",
-        "zone": "ドードリの汚水槽",
-        "level": 47,
-        "zone_en": "Doedre's Cesspool"
-      },
-      {
-        "id": "act8_area5",
-        "zone": "大釜",
-        "level": 48
-      },
-      {
-        "id": "act8_area6",
-        "zone": "波止場",
-        "level": 48,
-        "zone_en": "The Quay"
-      },
-      {
-        "id": "act8_area7",
-        "zone": "復活の地",
-        "level": 49
-      },
-      {
-        "id": "act8_area8",
-        "zone": "穀物倉庫",
-        "level": 49,
-        "zone_en": "The Grain Gate"
-      },
-      {
-        "id": "act8_area9",
-        "zone": "帝国の穀倉地帯",
-        "level": 50,
-        "zone_en": "The Imperial Fields"
-      },
-      {
-        "id": "act8_area10",
-        "zone": "ソラリス寺院 -第一層-",
-        "level": 50,
-        "zone_en": "The Solaris Temple Level 1"
-      },
-      {
-        "id": "act8_area11",
-        "zone": "ソラリス寺院 -第二層-",
-        "level": 50,
-        "zone_en": "The Solaris Temple Level 2"
-      },
-      {
-        "id": "act8_area12",
-        "zone": "ソラリスの中央広場",
-        "level": 50,
-        "zone_en": "The Solaris Concourse"
-      },
-      {
-        "id": "act8_area13",
-        "zone": "港の橋",
-        "level": 51,
-        "zone_en": "The Harbour Bridge"
-      },
-      {
-        "id": "act8_area14",
-        "zone": "ルナリスの中央広場",
-        "level": 51,
-        "zone_en": "The Lunaris Concourse"
-      },
-      {
-        "id": "act8_area15",
-        "zone": "ルナリス寺院 -第一層-",
-        "level": 51,
-        "zone_en": "The Lunaris Temple Level 1"
-      },
-      {
-        "id": "act8_area16",
-        "zone": "ルナリス寺院 -第二層-",
-        "level": 52,
-        "zone_en": "The Lunaris Temple Level 2"
-      },
-      {
-        "id": "act8_area17",
-        "zone": "血の水道橋",
-        "level": 48,
-        "zone_en": "The Blood Aqueduct"
-      },
-      {
-        "id": "act8_area18",
-        "zone": "浴場",
-        "level": 48,
-        "zone_en": "The Bath House"
-      },
-      {
-        "id": "act8_area19",
-        "zone": "空中庭園",
-        "level": 48,
-        "zone_en": "The High Gardens"
-      }
-    ],
-    "Act 9": [
-      {
-        "id": "act9_area1",
-        "zone": "谷底への道",
-        "level": 53,
-        "zone_en": "The Descent"
-      },
-      {
-        "id": "act9_area2",
-        "zone": "ヴァスティリ砂漠",
-        "level": 53,
-        "zone_en": "The Vastiri Desert"
-      },
-      {
-        "id": "act9_area3",
-        "zone": "オアシス",
-        "level": 54,
-        "zone_en": "The Oasis"
-      },
-      {
-        "id": "act9_area4",
-        "zone": "山麓",
-        "level": 54,
-        "zone_en": "The Foothills"
-      },
-      {
-        "id": "act9_area5",
-        "zone": "沸き立つ湖",
-        "level": 54,
-        "zone_en": "The Boiling Lake"
-      },
-      {
-        "id": "act9_area6",
-        "zone": "坑道",
-        "level": 54,
-        "zone_en": "The Tunnel"
-      },
-      {
-        "id": "act9_area7",
-        "zone": "採石場",
-        "level": 54,
-        "zone_en": "The Quarry"
-      },
-      {
-        "id": "act9_area8",
-        "zone": "精錬所",
-        "level": 54,
-        "zone_en": "The Refinery"
-      },
-      {
-        "id": "act9_area9",
-        "zone": "魔獣の内部",
-        "level": 54,
-        "zone_en": "The Belly of the Beast"
-      },
-      {
-        "id": "act9_area10",
-        "zone": "腐った核",
-        "level": 54,
-        "zone_en": "The Rotting Core"
-      }
-    ],
-    "Act 10": [
-      {
-        "id": "act10_area1",
-        "zone": "大聖堂の屋上",
-        "level": 58,
-        "zone_en": "The Cathedral Rooftop"
-      },
-      {
-        "id": "act10_area2",
-        "zone": "聖堂の屋上",
-        "level": 58
-      },
-      {
-        "id": "act10_area3",
-        "zone": "荒廃した広場",
-        "level": 59,
-        "zone_en": "The Ravaged Square"
-      },
-      {
-        "id": "act10_area4",
-        "zone": "奴隷管理区画",
-        "level": 60,
-        "zone_en": "The Control Blocks"
-      },
-      {
-        "id": "act10_area5",
-        "zone": "納骨堂",
-        "level": 61,
-        "zone_en": "The Ossuary"
-      },
-      {
-        "id": "act10_area6",
-        "zone": "焼けた裁判所",
-        "level": 62,
-        "zone_en": "The Torched Courts"
-      },
-      {
-        "id": "act10_area7",
-        "zone": "冒涜された広間",
-        "level": 63,
-        "zone_en": "The Desecrated Chambers"
-      },
-      {
-        "id": "act10_area8",
-        "zone": "志す者の広場",
-        "level": 67,
-        "zone_en": "Aspirants' Plaza"
-      },
-      {
-        "id": "act10_area9",
-        "zone": "運河",
-        "level": 60,
-        "zone_en": "The Canals"
-      },
-      {
-        "id": "act10_area10",
-        "zone": "餌場",
-        "level": 60,
-        "zone_en": "The Feeding Trough"
-      },
-      {
-        "id": "act10_area11",
-        "zone": "渇望の祭壇",
-        "level": 60
-      }
-    ]
-  },
-  "guide_expanded": true,
-  "guide_font_size": 18,
-  "town_zones": [
-    "Lioneye's Watch",
-    "ライオンアイの見張り場",
-    "The Forest Encampment",
-    "森の野営地",
-    "The Sarn Encampment",
-    "サーンの野営地",
-    "Highgate",
-    "ハイゲート",
-    "Overseer's Tower",
-    "監督官の塔",
-    "The Bridge Encampment",
-    "橋の野営地",
-    "Oriath Docks",
-    "オリアスの船着場",
-    "Karui Shores",
-    "カルイの海岸"
-  ],
-  "part2_mode": false,
-  "timer_expanded": true,
-  "map_viewer_width": 807,
-  "map_viewer_height": 692,
-  "lap_expanded": true,
-  "client_log_path": "",
-  "timer_size": "large",
-  "setup_completed": false,
-  "window_locked": false,
-  "window_opacity": 55,
-  "auto_lap": true
+    "part2_mode": false,
+    "timer_expanded": true,
+    "map_viewer_width": 807,
+    "map_viewer_height": 693,
+    "lap_expanded": false,
+    "client_log_path": "/mnt/c/PathOfExile/logs/Client.txt",
+    "timer_size": "large",
+    "setup_completed": true,
+    "window_locked": false,
+    "window_opacity": 55,
+    "auto_lap": false,
+    "display_monitor": 1,
+    "auto_open_map": true,
+    "auto_position_map": true
 }

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -109,6 +109,8 @@ class MainWindow(QMainWindow):
         self.current_act = 1  # 1-10
         
         self.setup_ui()
+        self.map_thumbnail.auto_open = self.config.get("auto_open_map", False)
+        self.map_thumbnail.auto_position = self.config.get("auto_position_map", True)
         self.setMouseTracking(True)
         self.centralWidget().setMouseTracking(True)
         self._apply_bg_opacity(self.config.get("window_opacity", 100))
@@ -1325,9 +1327,9 @@ class MainWindow(QMainWindow):
             self.advice_label.setStyleSheet("color: #888888; font-size: 12px;")
         
         # 攻略ガイド・マップ更新
-        self._update_guide_and_map(zone_name, zone_id, visit_num)
+        self._update_guide_and_map(zone_name, zone_id, visit_num, zone_changed=True)
     
-    def _update_guide_and_map(self, zone_name: str, zone_id: str | None, visit_num: int):
+    def _update_guide_and_map(self, zone_name: str, zone_id: str | None, visit_num: int, zone_changed: bool = False):
         """攻略ガイドとマップ画像を更新"""
         # 訪問回数オーバーライド適用
         effective_visit = self.visit_override if self.visit_override is not None else visit_num
@@ -1352,7 +1354,7 @@ class MainWindow(QMainWindow):
                     if z.get("id") == zone_id:
                         map_zone_name = z["zone"]  # 日本語名
                         break
-        self.map_thumbnail.load_maps(map_zone_name, part2=self.part2_mode)
+        self.map_thumbnail.load_maps(map_zone_name, part2=self.part2_mode, zone_changed=zone_changed)
     
     def on_kitava_defeated(self):
         """Act5キタヴァ討伐 → Act6-10に切替 + 自動ラップ"""
@@ -1542,6 +1544,9 @@ class MainWindow(QMainWindow):
             
             # ウィンドウロック更新
             self.window_locked = self.config.get("window_locked", False)
+            # マップ自動表示更新
+            self.map_thumbnail.auto_open = self.config.get("auto_open_map", False)
+            self.map_thumbnail.auto_position = self.config.get("auto_position_map", True)
             # 透過率更新
             self._apply_bg_opacity(self.config.get("window_opacity", 100))
             

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -25,8 +25,14 @@ class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("ぽえなび")
-        self.resize(420, 1200)
-        
+
+        # config の display_monitor で指定されたモニターの右端に縦長で配置
+        from PySide6.QtWidgets import QApplication
+        _config = ConfigManager.load_config()
+        self._display_monitor_index = _config.get("display_monitor", 0)
+        self._initial_positioned = False
+        self.resize(420, 1200)  # 仮サイズ、showEvent で実際に配置
+
         # アプリアイコン設定
         icon_path = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), "icon.ico")
         if not os.path.exists(icon_path):
@@ -1549,6 +1555,27 @@ class MainWindow(QMainWindow):
             visit_num = self.zone_visit_counts.get(self.current_zone, 1)
             self._update_guide_and_map(self.current_zone, zone_id, visit_num)
             
+    def showEvent(self, event):
+        super().showEvent(event)
+        if not self._initial_positioned:
+            self._initial_positioned = True
+            from PySide6.QtWidgets import QApplication
+            screens = QApplication.screens()
+            idx = self._display_monitor_index
+            if screens and 0 <= idx < len(screens):
+                target_screen = screens[idx]
+            elif screens:
+                target_screen = screens[0]
+            else:
+                return
+            geo = target_screen.availableGeometry()
+            actual_w = self.frameGeometry().width()
+            win_h = geo.height()
+            self.resize(self.width(), win_h)
+            x = geo.left() + geo.width() - actual_w
+            y = geo.top()
+            self.move(x, y)
+
     def closeEvent(self, event):
         if self.keyboard_listener:
             self.keyboard_listener.stop()

--- a/src/ui/map_viewer.py
+++ b/src/ui/map_viewer.py
@@ -8,7 +8,7 @@ import sys
 from PySide6.QtWidgets import (
     QWidget, QHBoxLayout, QVBoxLayout, QLabel, QDialog
 )
-from PySide6.QtCore import Qt, QSize, Signal, QPoint
+from PySide6.QtCore import Qt, QSize, Signal, QPoint, QTimer
 from PySide6.QtGui import QPixmap, QCursor, QPainter
 
 
@@ -106,7 +106,8 @@ class MapImageDialog(QDialog):
         self.all_paths = all_paths or [image_path]
         self.current_index = self.all_paths.index(image_path) if image_path in self.all_paths else 0
         self._pixmaps = {}  # キャッシュ
-        self._target_pos = None  # showEvent で適用する位置
+        self._target_pos = None
+        self._positioned = False
 
         self.setWindowTitle(os.path.basename(image_path))
         self.setWindowFlags(Qt.Dialog | Qt.WindowStaysOnTopHint)
@@ -177,13 +178,15 @@ class MapImageDialog(QDialog):
     
     def showEvent(self, event):
         super().showEvent(event)
-        if self._target_pos is not None:
-            self.move(self._target_pos)
-            # exec() がイベントループ内で再配置するのを上書き
-            from PySide6.QtCore import QTimer
+        if self._target_pos is not None and not self._positioned:
+            self._positioned = True
+            self.hide()
             pos = self._target_pos
-            QTimer.singleShot(10, lambda: self.move(pos))
-            QTimer.singleShot(50, lambda: self.move(pos))
+            QTimer.singleShot(10, lambda: self._apply_position(pos))
+
+    def _apply_position(self, pos):
+        self.move(pos)
+        self.show()
 
     def resizeEvent(self, event):
         super().resizeEvent(event)
@@ -240,6 +243,8 @@ class MapThumbnailWidget(QWidget):
         self.current_paths = []
         self._thumbs = []
         self._open_dialog = None
+        self.auto_open = False
+        self.auto_position = True
         
         self.setStyleSheet("background: transparent;")
         
@@ -263,7 +268,7 @@ class MapThumbnailWidget(QWidget):
         
         main_layout.addWidget(self.thumb_container)
     
-    def load_maps(self, zone_name: str, part2: bool = False):
+    def load_maps(self, zone_name: str, part2: bool = False, zone_changed: bool = False):
         """ゾーンのマップ画像を読み込んで表示"""
         # 開いているマップダイアログを閉じる
         if self._open_dialog is not None:
@@ -298,51 +303,59 @@ class MapThumbnailWidget(QWidget):
             thumb.clicked.connect(self._on_thumb_clicked)
             self._thumbs.append(thumb)
             row_layout.addWidget(thumb)
-    
+
+        # auto_open が有効 かつ エリア移動時のみ自動的にダイアログを開く
+        if self.auto_open and zone_changed and paths:
+            self._on_thumb_clicked(paths[0])
+
     def _on_thumb_clicked(self, image_path: str):
         """サムネイルクリック → 拡大表示（メインウィンドウと同じモニターの左隣に配置）"""
         # 親なしで作成（exec()による親基準の中央配置を防ぐ）
         dialog = MapImageDialog(image_path, all_paths=self.current_paths, parent=None)
 
         # メインウィンドウがいるモニター基準で隣に配置
-        main_win = self.window()
-        if main_win:
-            from PySide6.QtWidgets import QApplication
-            main_geo = main_win.frameGeometry()
-            dialog_w = dialog.width()
-            dialog_h = dialog.height()
+        if self.auto_position:
+            main_win = self.window()
+            if main_win:
+                from PySide6.QtWidgets import QApplication
+                main_geo = main_win.frameGeometry()
+                dialog_w = dialog.width()
+                dialog_h = dialog.height()
 
-            # メインウィンドウがいるモニターを特定
-            main_center = main_geo.center()
-            screen = QApplication.screenAt(main_center)
-            if not screen:
-                screen = QApplication.primaryScreen()
-            if screen:
-                sg = screen.availableGeometry()
+                # メインウィンドウがいるモニターを特定
+                main_center = main_geo.center()
+                screen = QApplication.screenAt(main_center)
+                if not screen:
+                    screen = QApplication.primaryScreen()
+                if screen:
+                    sg = screen.availableGeometry()
 
-                # 左側にぴったりくっつけて配置（同じモニター内に収める）
-                left_x = main_geo.left() - dialog_w
-                right_x = main_geo.right() + 1
+                    # 左側にぴったりくっつけて配置（同じモニター内に収める）
+                    left_x = main_geo.left() - dialog_w
+                    right_x = main_geo.right() + 1
 
-                if left_x >= sg.left():
-                    x = left_x
-                elif right_x + dialog_w <= sg.left() + sg.width():
-                    x = right_x
-                else:
-                    x = sg.left()
+                    if left_x >= sg.left():
+                        x = left_x
+                    elif right_x + dialog_w <= sg.left() + sg.width():
+                        x = right_x
+                    else:
+                        x = sg.left()
 
-                # 縦位置はメインウィンドウの上端に合わせる（画面内に収める）
-                y = main_geo.top()
-                if y + dialog_h > sg.top() + sg.height():
-                    y = max(sg.top(), sg.top() + sg.height() - dialog_h)
+                    # 縦位置はメインウィンドウの上端に合わせる（画面内に収める）
+                    y = main_geo.top()
+                    if y + dialog_h > sg.top() + sg.height():
+                        y = max(sg.top(), sg.top() + sg.height() - dialog_h)
 
-                dialog.move(x, y)
-                dialog._target_pos = QPoint(x, y)
+                    dialog._target_pos = QPoint(x, y)
 
         self._open_dialog = dialog
-        dialog.exec()
-        self._open_dialog = None
+        dialog.finished.connect(self._on_dialog_closed)
+        dialog.open()
     
+    def _on_dialog_closed(self):
+        """ダイアログが閉じられた時の後片付け"""
+        self._open_dialog = None
+
     def _clear_thumbs(self):
         """サムネイルを全削除"""
         for thumb in self._thumbs:

--- a/src/ui/map_viewer.py
+++ b/src/ui/map_viewer.py
@@ -8,7 +8,7 @@ import sys
 from PySide6.QtWidgets import (
     QWidget, QHBoxLayout, QVBoxLayout, QLabel, QDialog
 )
-from PySide6.QtCore import Qt, QSize, Signal
+from PySide6.QtCore import Qt, QSize, Signal, QPoint
 from PySide6.QtGui import QPixmap, QCursor, QPainter
 
 
@@ -106,7 +106,8 @@ class MapImageDialog(QDialog):
         self.all_paths = all_paths or [image_path]
         self.current_index = self.all_paths.index(image_path) if image_path in self.all_paths else 0
         self._pixmaps = {}  # キャッシュ
-        
+        self._target_pos = None  # showEvent で適用する位置
+
         self.setWindowTitle(os.path.basename(image_path))
         self.setWindowFlags(Qt.Dialog | Qt.WindowStaysOnTopHint)
         self.setStyleSheet("background: #111122;")
@@ -174,6 +175,16 @@ class MapImageDialog(QDialog):
         self.info_label.setText(f"{fname}  ({idx}/{total})   {nav_hint}")
         self.setWindowTitle(f"{fname} ({idx}/{total})")
     
+    def showEvent(self, event):
+        super().showEvent(event)
+        if self._target_pos is not None:
+            self.move(self._target_pos)
+            # exec() がイベントループ内で再配置するのを上書き
+            from PySide6.QtCore import QTimer
+            pos = self._target_pos
+            QTimer.singleShot(10, lambda: self.move(pos))
+            QTimer.singleShot(50, lambda: self.move(pos))
+
     def resizeEvent(self, event):
         super().resizeEvent(event)
         # リサイズ時に画像を再フィット
@@ -189,6 +200,20 @@ class MapImageDialog(QDialog):
         ConfigManager.save_config(config)
         super().closeEvent(event)
     
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton and len(self.all_paths) > 1:
+            # ダイアログの左半分クリック → 前へ、右半分 → 次へ
+            if event.position().x() >= self.width() / 2:
+                if self.current_index < len(self.all_paths) - 1:
+                    self.current_index += 1
+                    self._show_image()
+            else:
+                if self.current_index > 0:
+                    self.current_index -= 1
+                    self._show_image()
+        else:
+            super().mousePressEvent(event)
+
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Escape:
             self.close()
@@ -214,6 +239,7 @@ class MapThumbnailWidget(QWidget):
         super().__init__(parent)
         self.current_paths = []
         self._thumbs = []
+        self._open_dialog = None
         
         self.setStyleSheet("background: transparent;")
         
@@ -239,6 +265,10 @@ class MapThumbnailWidget(QWidget):
     
     def load_maps(self, zone_name: str, part2: bool = False):
         """ゾーンのマップ画像を読み込んで表示"""
+        # 開いているマップダイアログを閉じる
+        if self._open_dialog is not None:
+            self._open_dialog.close()
+            self._open_dialog = None
         self._clear_thumbs()
         
         paths = load_zone_maps(zone_name, part2=part2)
@@ -270,9 +300,48 @@ class MapThumbnailWidget(QWidget):
             row_layout.addWidget(thumb)
     
     def _on_thumb_clicked(self, image_path: str):
-        """サムネイルクリック → 拡大表示"""
-        dialog = MapImageDialog(image_path, all_paths=self.current_paths, parent=self.window())
+        """サムネイルクリック → 拡大表示（メインウィンドウと同じモニターの左隣に配置）"""
+        # 親なしで作成（exec()による親基準の中央配置を防ぐ）
+        dialog = MapImageDialog(image_path, all_paths=self.current_paths, parent=None)
+
+        # メインウィンドウがいるモニター基準で隣に配置
+        main_win = self.window()
+        if main_win:
+            from PySide6.QtWidgets import QApplication
+            main_geo = main_win.frameGeometry()
+            dialog_w = dialog.width()
+            dialog_h = dialog.height()
+
+            # メインウィンドウがいるモニターを特定
+            main_center = main_geo.center()
+            screen = QApplication.screenAt(main_center)
+            if not screen:
+                screen = QApplication.primaryScreen()
+            if screen:
+                sg = screen.availableGeometry()
+
+                # 左側にぴったりくっつけて配置（同じモニター内に収める）
+                left_x = main_geo.left() - dialog_w
+                right_x = main_geo.right() + 1
+
+                if left_x >= sg.left():
+                    x = left_x
+                elif right_x + dialog_w <= sg.left() + sg.width():
+                    x = right_x
+                else:
+                    x = sg.left()
+
+                # 縦位置はメインウィンドウの上端に合わせる（画面内に収める）
+                y = main_geo.top()
+                if y + dialog_h > sg.top() + sg.height():
+                    y = max(sg.top(), sg.top() + sg.height() - dialog_h)
+
+                dialog.move(x, y)
+                dialog._target_pos = QPoint(x, y)
+
+        self._open_dialog = dialog
         dialog.exec()
+        self._open_dialog = None
     
     def _clear_thumbs(self):
         """サムネイルを全削除"""
@@ -290,6 +359,9 @@ class MapThumbnailWidget(QWidget):
     
     def clear(self):
         """表示をクリア"""
+        if self._open_dialog is not None:
+            self._open_dialog.close()
+            self._open_dialog = None
         self._clear_thumbs()
         self.current_paths = []
         self.setVisible(False)

--- a/src/ui/settings_dialog.py
+++ b/src/ui/settings_dialog.py
@@ -767,8 +767,25 @@ class SettingsDialog(QDialog):
         self.window_lock_check.setChecked(self.current_config.get("window_locked", False))
         lock_layout.addWidget(self.window_lock_check)
         lock_layout.addStretch()
-        
+
         general_layout.addWidget(lock_group)
+
+        # マップ表示設定
+        map_group = QGroupBox("マップ表示")
+        map_group.setStyleSheet(group.styleSheet())
+        map_layout = QVBoxLayout(map_group)
+
+        self.auto_open_map_check = QCheckBox("エリア移動時にマップレイアウトを自動で開く")
+        self.auto_open_map_check.setStyleSheet(self.window_lock_check.styleSheet())
+        self.auto_open_map_check.setChecked(self.current_config.get("auto_open_map", False))
+        map_layout.addWidget(self.auto_open_map_check)
+
+        self.auto_position_map_check = QCheckBox("マップウィンドウをメインウィンドウの隣に自動配置する")
+        self.auto_position_map_check.setStyleSheet(self.window_lock_check.styleSheet())
+        self.auto_position_map_check.setChecked(self.current_config.get("auto_position_map", True))
+        map_layout.addWidget(self.auto_position_map_check)
+
+        general_layout.addWidget(map_group)
         
         # 街エリア設定
         town_group = QGroupBox("街エリア（ガイド更新スキップ）")
@@ -1076,5 +1093,7 @@ class SettingsDialog(QDialog):
             "timer_size": self.timer_size_combo.currentData(),
             "window_opacity": self.opacity_slider.value(),
             "window_locked": self.window_lock_check.isChecked(),
+            "auto_open_map": self.auto_open_map_check.isChecked(),
+            "auto_position_map": self.auto_position_map_check.isChecked(),
             "town_zones": [z.strip() for z in self.town_zones_edit.toPlainText().split("\n") if z.strip()],
         }


### PR DESCRIPTION
## Summary
- 起動時にconfigの`display_monitor`で指定したモニターの右端に縦長で自動配置
- マップレイアウトの拡大ダイアログをメインウィンドウと同じモニターの隣に表示
- 拡大画像の左右クリックで画像送り機能を追加
- エリア移動時に開いているマップダイアログを自動クローズ
- **マップレイアウト自動表示機能を追加**（`auto_open_map`設定）
  - エリア移動時にマップ画像が存在する場合、自動的にダイアログを表示
  - 街エリアやマップ画像がないエリアでは動作しない
- **マップダイアログの位置自動制御をオプション化**（`auto_position_map`設定）
  - メインウィンドウの隣への自動配置をON/OFF可能に
- ダイアログを`exec()`から`open()`に変更し非ブロッキング化
  - エリア移動時のダイアログ自動クローズが確実に動作
  - hide→move→showによるフリッカー防止
- 設定画面に「マップ表示」グループを追加
  - 「エリア移動時にマップレイアウトを自動で開く」チェックボックス
  - 「マップウィンドウをメインウィンドウの隣に自動配置する」チェックボックス

## Test plan
- [ ] `display_monitor` を変更してモニター間の配置切替を確認
- [ ] マップサムネイルクリック時にメインウィンドウの隣に表示されることを確認
- [ ] 拡大画像の左半分/右半分クリックで画像送りが動作することを確認
- [ ] エリア移動時にマップダイアログが自動で閉じることを確認
- [ ] `auto_open_map: true` でエリア移動時にマップダイアログが自動表示されることを確認
- [ ] `auto_open_map: false` で従来通りクリック操作が必要なことを確認
- [ ] マップ画像がないエリアではダイアログが開かないことを確認
- [ ] 街エリアでは動作しないことを確認
- [ ] `auto_position_map: false` でWMデフォルト位置に表示されることを確認
- [ ] 設定画面から各オプションのON/OFFが即時反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)